### PR TITLE
Fix Gba thumb SpRelLoadStore disasm offset

### DIFF
--- a/Core/GBA/Debugger/GbaDisUtils.cpp
+++ b/Core/GBA/Debugger/GbaDisUtils.cpp
@@ -269,7 +269,7 @@ void GbaDisUtils::ThumbDisassemble(DisassemblyInfo& info, string& out, uint32_t 
 
 			str.Write(' ');
 			WriteReg(str, rd);
-			str.WriteAll(", [SP, #$", HexUtilities::ToHex(immValue << 1), ']');
+			str.WriteAll(", [SP, #$", HexUtilities::ToHex(immValue << 2), ']');
 			break;
 		}
 


### PR DESCRIPTION
From GBATEK:
  7-0    nn - Unsigned Offset              (0-1020, step 4)

ARM documentation agrees:
https://developer.arm.com/documentation/dui0489/h/arm-and-thumb-instructions/ldr-and-str--immediate-offset- 
16-bit Thumb, word, Rn is SP (immediate offset): 0 to 1020

And the Cpu core implementation also has an offset with step 4: 
https://github.com/SourMesen/Mesen2/blob/master/Core/GBA/GbaCpu.Thumb.cpp#L235

```c
uint16_t immValue = (_opCode & 0xFF) << 2;
```